### PR TITLE
Fixed incorrect trigger variable that should be triggers

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -28,7 +28,7 @@ DEBUG=False
 
 __title__ = "Window Switcher Plus"
 __version__ = "0.4.6"
-__trigger__ = " "
+__triggers__ = " "
 __authors__ = ["Ed Perez", "Manuel Schneider", "dshoreman", "Viet Tran"]
 __exec_deps__ = ["wmctrl"]
 


### PR DESCRIPTION
The correct syntax is `__triggers__` for this to work.